### PR TITLE
release-drafterの追加

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,30 @@
+name-template: 'v$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    labels:
+      - 'chore'
+change-title-escapes: '\<*_&'
+exclude-labels:
+  - 'exclude from changelog'
+template: |
+   ## Changes
+
+   $CHANGES
+
+autolabeler:
+- label: feature
+  branch:
+    - '/^feature[/-].+/'
+- label: fix
+  branch:
+    - '/^fix[/-].+/'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,122 @@
+name: Release Drafter
+# リリースを自動で付ける
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - main
+  # pull_request event is required only for autolabeler
+  # pull_request:
+  #   # Only following types are handled by the action, but one can default to all as well
+  #   types: [opened, reopened, synchronize]
+  # pull_request_target event is required for autolabeler to support PRs from forks
+  # pull_request_target:
+  #   types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        configuration: [Release]
+
+    runs-on: windows-latest # For a list of available runner types, refer to
+
+    env:
+      Solution_Name: THERB-GH.sln
+      Plugin_File_Name: THERB-GH
+
+    steps:
+      # git のチェックアウトを行い、この環境に対象のリポを取得する
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      # Vusial Studio (MSBuild)のセットアップをする
+      - name: Setup MSBuild.exe
+        uses: microsoft/setup-msbuild@v1
+
+      # nuget のセットアップをする
+      - name: Setup NuGet
+        uses: NuGet/setup-nuget@v1
+
+      # solution ファイルの状態を復元する
+      # 例えば、nuget で参照しているファイルを取得するなど
+      - name: Restore the application
+        run: msbuild $env:Solution_Name /t:Restore /p:Configuration=$env:Configuration
+        env:
+          Configuration: ${{ matrix.configuration }}
+
+      # Build 実行
+      - name: Build the application
+        run: msbuild $env:Solution_Name /p:Configuration=$env:Configuration
+        env:
+          Configuration: ${{ matrix.configuration }}
+
+      # Test を実行
+      # - name: Run Test
+      #   run: dotnet test THERB-GH\bin\Release\THERB-GH.dll
+
+      - name: Copy items to /Release dir
+        if: ${{ matrix.configuration == 'Release' }} # Only upload gha from a release build
+        shell: powershell
+        run: |
+          cp ./example ./Release/example -recurse
+          cp ./LICENSE ./Release/LICENSE.txt
+          cp ./THERB-GH/bin/Release/net48 ./Release/THERB-GH -recurse
+
+      # 対象パスにあるファイルを GitHub にアップロードする
+      - name: Upload release build of plugin as artefact
+        if: ${{ matrix.configuration == 'Release' }} # Only upload gha from a release build
+        uses: actions/upload-artifact@v2
+        with:
+          name: THERB-GH 
+          path: ./Release
+  
+  update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      # THERB-GHのassetを作成
+      - run: mkdir -p ReleaseFile
+      - uses: actions/download-artifact@v3
+        id: test
+        with:
+          name: 'THERB-GH'
+          path: THERB-GH
+      - name: ZIP build
+        run: zip -r ReleaseFile.zip THERB-GH
+
+      # (Optional) GitHub Enterprise requires GHE_HOST variable set
+      #- name: Set GHE_HOST
+      #  run: |
+      #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
+
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+
+      - name: create release
+        id: create_release
+        uses: release-drafter/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Upload Release Asset
+        id: upload-release-asset 
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps 
+          asset_path: ReleaseFile.zip
+          asset_name: THERB-GH-${{ steps.create_release.outputs.tag_name }}.zip
+          asset_content_type: application/zip

--- a/.github/workflows/run-autolabeler.yml
+++ b/.github/workflows/run-autolabeler.yml
@@ -1,0 +1,43 @@
+name: run-autolabeler
+# PRに自動でラベルを付ける
+
+on:
+  # push:
+  #   # branches to consider in the event; optional, defaults to all
+  #   branches:
+  #     - main
+  # pull_request event is required only for autolabeler
+  pull_request:
+    # Only following types are handled by the action, but one can default to all as well
+    types: [opened, reopened, synchronize]
+  # pull_request_target event is required for autolabeler to support PRs from forks
+  # pull_request_target:
+  #   types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      # (Optional) GitHub Enterprise requires GHE_HOST variable set
+      #- name: Set GHE_HOST
+      #  run: |
+      #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
+
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - uses: release-drafter/release-drafter@v5
+        id: create_release
+        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
+        # with:
+        #   config-name: my-config.yml
+        #   disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
[release-drafter](https://github.com/release-drafter/release-drafter)を追加しました。

Public archiveの[upload-release-asset](https://github.com/actions/upload-release-asset)を使用しているため、メンテナンスしていない弊害が生まれるかもです。